### PR TITLE
docs: fix typo, reponsible -> responsible

### DIFF
--- a/packages/optivorbis/src/vorbis/optimizer.rs
+++ b/packages/optivorbis/src/vorbis/optimizer.rs
@@ -1,4 +1,4 @@
-//! Contains the [`VorbisOptimizer`] struct, which is reponsible for optimizing
+//! Contains the [`VorbisOptimizer`] struct, which is responsible for optimizing
 //! unencapsulated, raw Vorbis streams.
 //!
 //! [`Remuxers`](crate::remuxer) are the primary intended consumers of this


### PR DESCRIPTION
Found via `typos --format brief`